### PR TITLE
fix #12

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -82,6 +82,7 @@
 \input{maegaki}
 \clearpage % tocloft パッケージを使う場合は自分で \clearpage しないといけない
 \tableofcontents
+\cleardoublepage
 \mainmatter
 {\subfile{ueda}}
 {\subfile{inoue}}

--- a/main.tex
+++ b/main.tex
@@ -82,7 +82,7 @@
 \input{maegaki}
 \clearpage % tocloft パッケージを使う場合は自分で \clearpage しないといけない
 \tableofcontents
-\cleardoublepage
+\cleardoublepage % 本文を見開き右から始めるために追加（ヘッダのページ数表示の関係上右始めの必要あり） 2018/7/10 by Okudenn
 \mainmatter
 {\subfile{ueda}}
 {\subfile{inoue}}


### PR DESCRIPTION
なんとか前のプルリクエストを取り消しました．
これなら最悪1行なのでマージして失敗してもすぐ直せるかと思います．

main.tex に `\cleardoublepage` を加え，必要ならば最大1ページの空白ページを加えることで本文が必ず見開き右から始まるようにしました．これにより issue #12 が解消されるかと思います．
確認していただきたい点として，`\begin{comment}  \end{comment}` などで適当にコメントアウトして前書きを1ページに収めた際，**空白ページは挿入されず**，本文が右ページから始まるということです．あと，適当に前書きをコピペして3ページ4ページに増えた際にも望む挙動になっていることを確かめていただけるとなお安心です．

どうぞよろしくお願いいたします．